### PR TITLE
Supports python3 urlparse

### DIFF
--- a/docker_links.py
+++ b/docker_links.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 import re
-from urlparse import urlparse
+try:   # python 2.x
+    from urlparse import urlparse
+except:  # python 3.x
+    from urllib.parse import urlparse
 
 
 def parse_links(env):


### PR DESCRIPTION
Python 3.x has urlparse in a different spot in the standard library, so this change supports importing either one
