### PR TITLE
Adds support for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+sudo: false  # enables docker-based Travis builds
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "nightly"
+  - "pypy"
+script: python tests.py


### PR DESCRIPTION
This tells Travis to run the test cases in all of the supported versions of Python
